### PR TITLE
Allow jenkins to use the docker host daemon

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3.2'
 services:
   jenkins:
+    user: root
     image: jenkinsci/blueocean:latest
     ports:
       - "50000:50000"
@@ -9,6 +10,9 @@ services:
       - type: volume
         source: jenkins_home
         target: /var/jenkins_home 
+      - type: bind
+        source: /var/run/docker.sock
+        target: /var/run/docker.sock
   nginx:
     build:
       context: nginx


### PR DESCRIPTION
* Bind mount the docker.sock so that the docker client can communicate
  with the host docker daemon
* Use user root to work around potential uid/gid mapping issues for docker.sock

More information:
https://jenkins.io/doc/book/installing/#docker
https://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/
http://container-solutions.com/continuous-delivery-with-docker-on-mesos-in-less-than-a-minute/